### PR TITLE
Ensure Kayessess assets are available to the loaded environment (when loaded via engine)

### DIFF
--- a/lib/kayessess/engine.rb
+++ b/lib/kayessess/engine.rb
@@ -4,6 +4,11 @@ module Kayessess
     isolate_namespace Kayessess
     engine_name "kayessess"
 
+    # Ensure assets are available to loaded environment
+    initializer "kayessess.assets.precompile" do |app|
+      app.config.assets.precompile += [/kayessess\/kayessess\.(js|css)/]
+    end
+
     # Ensure that application helpers are available to kayessess.
     # This is important as we need to make sure that application helpers can be
     # used within styleguide examples.


### PR DESCRIPTION
Tested on Rails 4.1 but judging from the guides should work in the same way with Rails 3.x.

Fixes https://github.com/aerobicio/kayessess/issues/4
