### PR TITLE
Fix references in gemfile, always list gemspec, then Gemfile, never both

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,14 +9,6 @@ gem 'awesome_print'
 
 group :test, :development do
   gem 'actionpack'
-  gem 'appraisal'
   gem 'cane'
-  gem 'combustion', '~> 0.4.0'
-  gem 'coveralls', require: false
-  gem 'rake'
-  gem 'rspec'
-  gem 'rspec-rails', '~> 2.13'
-  gem 'shoulda-matchers'
-  gem 'simplecov', require: false
   gem 'sprockets'
 end

--- a/gemfiles/rails3.0.x.gemfile
+++ b/gemfiles/rails3.0.x.gemfile
@@ -7,4 +7,10 @@ gem "neat"
 gem "awesome_print"
 gem "rails", "~> 3.0"
 
-gemspec :path=>"../"
+group :test, :development do
+  gem "actionpack"
+  gem "cane"
+  gem "sprockets"
+end
+
+gemspec :path => "../"

--- a/gemfiles/rails3.1.x.gemfile
+++ b/gemfiles/rails3.1.x.gemfile
@@ -7,4 +7,10 @@ gem "neat"
 gem "awesome_print"
 gem "rails", "~> 3.1"
 
-gemspec :path=>"../"
+group :test, :development do
+  gem "actionpack"
+  gem "cane"
+  gem "sprockets"
+end
+
+gemspec :path => "../"

--- a/gemfiles/rails3.2.x.gemfile
+++ b/gemfiles/rails3.2.x.gemfile
@@ -7,4 +7,10 @@ gem "neat"
 gem "awesome_print"
 gem "rails", "~> 3.2"
 
-gemspec :path=>"../"
+group :test, :development do
+  gem "actionpack"
+  gem "cane"
+  gem "sprockets"
+end
+
+gemspec :path => "../"

--- a/gemfiles/rails4.0.x.gemfile
+++ b/gemfiles/rails4.0.x.gemfile
@@ -7,4 +7,10 @@ gem "neat"
 gem "awesome_print"
 gem "rails", "~> 4.0"
 
-gemspec :path=>"../"
+group :test, :development do
+  gem "actionpack"
+  gem "cane"
+  gem "sprockets"
+end
+
+gemspec :path => "../"

--- a/kayessess.gemspec
+++ b/kayessess.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rspec-nc'
-  s.add_development_dependency 'rspec-rails', '~> 2.13'
+  s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'shoulda-matchers'
   s.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
Bad:
![screen shot 2014-05-22 at 5 17 38 pm](https://cloud.githubusercontent.com/assets/19973/3050860/b8a1648a-e181-11e3-8711-aa3c759bd8e3.png)

Listing 'gemspec' in gemfile, means it will load in the references, listing in the same references means duplication and bad times.
