### PR TITLE
Make styleguide location configurable

### DIFF
--- a/app/controllers/kayessess/application_controller.rb
+++ b/app/controllers/kayessess/application_controller.rb
@@ -9,7 +9,7 @@ module Kayessess
     def parse_styles
       require 'kss'
 
-      parser = Kss::Parser.new(File.join(Rails.root, '/app/assets/stylesheets'))
+      parser = Kss::Parser.new(File.join(Rails.root, Kayessess.styleguide_location || '/app/assets/stylesheets'))
       @styleguide = Kayessess::Styleguide.new(parser)
     end
 

--- a/lib/kayessess.rb
+++ b/lib/kayessess.rb
@@ -6,6 +6,8 @@ require 'pygments'
 
 module Kayessess
 
+  mattr_accessor :styleguide_location
+
   # Helper class for adding Pygments syntax highlighting to Redcarpet
   class HTMLwithPygments < Redcarpet::Render::HTML
     def block_code(code, language)


### PR DESCRIPTION
## What

Not all apps keep their styleguide in `/app/assets/stylesheets`.

It was useful for me to be able to override this...
